### PR TITLE
add /avatar slash command

### DIFF
--- a/src/slashcommands/avatar.js
+++ b/src/slashcommands/avatar.js
@@ -1,0 +1,22 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('avatar')
+    .setDescription('Display user avatar')
+    .addUserOption(option =>
+      option.setName('user')
+        .setDescription('The user to get avatar from')
+        .setRequired(false)),
+  async execute(interaction) {
+    const user = interaction.options.getUser('user') || interaction.user;
+    const avatarURL = user.displayAvatarURL({ size: 512, dynamic: true });
+
+    const embed = new EmbedBuilder()
+      .setTitle(`${user.username}'s Avatar`)
+      .setImage(avatarURL)
+      .setColor('Blurple');
+
+    await interaction.reply({ embeds: [embed] });
+  },
+};


### PR DESCRIPTION
Closes #3

Added the `/avatar` slash command as described in the issue.

- Created `src/slashcommands/avatar.js`
- Added optional `user` option — defaults to the command user if not provided
- Fetches avatar using `displayAvatarURL()` with size 512 and animated support
- Displays the avatar inside a Discord embed with Blurple color