### PR TITLE
add error handling for unkown prefix commands

### DIFF
--- a/src/events/messageCreate.js
+++ b/src/events/messageCreate.js
@@ -9,7 +9,9 @@ module.exports = {
     const commandName = args.shift().toLowerCase();
     
     const command = message.client.prefixCommands.get(commandName);
-    if (!command) return;
+    if (!command) {
+      return message.reply(`Unknown command: \`${commandName}\`. Type \`!help\` to see available commands.`);
+    }
     
     try {
       command.execute(message, args);


### PR DESCRIPTION
Closes #4

Added friendly error handling for unknown prefix commands in `src/events/messageCreate.js`.

- When a user types an unknown command, bot now replies with a helpful message
- Suggests using `!help` to see available commands
- Follows defensive programming practices as described in the issue