### PR TITLE
feat: add /quote slash command

### DIFF
--- a/src/slashcommands/quote.js
+++ b/src/slashcommands/quote.js
@@ -1,0 +1,33 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('quote')
+    .setDescription('Fetch a random inspirational quote'),
+  async execute(interaction) {
+    try {
+      await interaction.deferReply();
+
+      const response = await fetch('https://api.quotable.io/random');
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+      const data = await response.json();
+
+      const embed = new EmbedBuilder()
+        .setTitle('Random Quote')
+        .setDescription(data.content)
+        .setFooter({ text: data.author })
+        .setColor(0x5865F2)
+        .setTimestamp();
+
+      await interaction.editReply({ embeds: [embed] });
+    } catch (error) {
+      console.error('Quote command error:', error);
+      await interaction.editReply({
+        content: 'Failed to fetch quote. Please try again.',
+        ephemeral: true,
+      });
+    }
+  },
+};


### PR DESCRIPTION
## Summary
- Added `/quote` slash command that fetches random inspirational quotes from https://api.quotable.io/random.
- Displays quotes in a Discord embed with title \"Random Quote\", quote content, author in the footer, blurple color (0x5865F2), and timestamp.
- Includes try/catch error handling with ephemeral error reply, following the existing command patterns.

## Test plan
- [ ] Run `/quote` and verify a random quote embed is returned.
- [ ] Verify error handling by simulating a network failure and checking for the ephemeral error message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)