### PR TITLE
[Reviewed] add /quote slash command to fetch random inspirational quotes

### DIFF
--- a/src/slashcommands/quote.js
+++ b/src/slashcommands/quote.js
@@ -1,0 +1,38 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('quote')
+    .setDescription('Get a random inspirational quote'),
+  async execute(interaction) {
+    try {
+      await interaction.deferReply();
+
+      const response = await fetch('https://api.quotable.io/random');
+      const data = await response.json();
+
+      // Handle unexpected API response
+      if (!data.content || !data.author) {
+        return await interaction.editReply({
+          content: 'Received an unexpected response from the API. Please try again.',
+          ephemeral: true,
+        });
+      }
+
+      const embed = new EmbedBuilder()
+        .setTitle('Random Quote')
+        .setDescription(`"${data.content}"`)
+        .setFooter({ text: `— ${data.author}` })
+        .setColor(0x5865F2)
+        .setTimestamp();
+
+      await interaction.editReply({ embeds: [embed] });
+    } catch (error) {
+      console.error('Quote command error:', error);
+      await interaction.editReply({
+        content: 'Failed to fetch a quote. Please try again later.',
+        ephemeral: true,
+      });
+    }
+  },
+};

--- a/src/slashcommands/quote.js
+++ b/src/slashcommands/quote.js
@@ -8,29 +8,38 @@ module.exports = {
     try {
       await interaction.deferReply();
 
-      const response = await fetch('https://api.quotable.io/random');
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 5000);
+
+      const response = await fetch('https://api.quotable.io/random', {
+        signal: controller.signal,
+      });
+      clearTimeout(timeout);
+
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+
       const data = await response.json();
 
-      // Handle unexpected API response
-      if (!data.content || !data.author) {
+      if (!data?.content || !data?.author) {
         return await interaction.editReply({
-          content: 'Received an unexpected response from the API. Please try again.',
+          content: '❌ Quote API returned unexpected format. Please try again.',
           ephemeral: true,
         });
       }
 
       const embed = new EmbedBuilder()
-        .setTitle('Random Quote')
-        .setDescription(`"${data.content}"`)
-        .setFooter({ text: `— ${data.author}` })
         .setColor(0x5865F2)
+        .setTitle('📜 Random Quote')
+        .setDescription(`"${data.content}"`)
+        .setFooter({ text: `— ${data.author} · Requested by ${interaction.user.tag}` })
         .setTimestamp();
 
       await interaction.editReply({ embeds: [embed] });
     } catch (error) {
+      clearTimeout;
       console.error('Quote command error:', error);
       await interaction.editReply({
-        content: 'Failed to fetch a quote. Please try again later.',
+        content: '❌ Failed to fetch a quote. Please try again later.',
         ephemeral: true,
       });
     }

--- a/src/slashcommands/quote.js
+++ b/src/slashcommands/quote.js
@@ -36,7 +36,7 @@ module.exports = {
 
       await interaction.editReply({ embeds: [embed] });
     } catch (error) {
-      clearTimeout;
+      clearTimeout(timeout);
       console.error('Quote command error:', error);
       await interaction.editReply({
         content: '❌ Failed to fetch a quote. Please try again later.',


### PR DESCRIPTION
Closes #18

Added the `/quote` slash command.

- Fetches a random quote from the Quotable API (no API key required)
- Displays quote and author in a blurple embed with timestamp
- Added a check for unexpected API responses
- Uses deferReply() to handle API latency
- try/catch for graceful error handling