### PR TITLE
[Reviewed] fix: correct commands path in deploy-commands.js (#1)

### DIFF
--- a/src/deploy-commands.js
+++ b/src/deploy-commands.js
@@ -4,7 +4,13 @@ const fs = require('fs');
 const path = require('path');
 
 const commands = [];
-const commandsPath = path.join(__dirname, 'commands');
+const commandsPath = path.join(__dirname, 'slashcommands');
+
+if (!fs.existsSync(commandsPath)) {
+  console.error(`Commands directory not found: ${commandsPath}`);
+  process.exit(1);
+}
+
 const commandFiles = fs.readdirSync(commandsPath).filter(f => f.endsWith('.js'));
 
 for (const file of commandFiles) {


### PR DESCRIPTION
Fixes issue #1 from #21

## Changes
- **Fixed path**: Changed 'commands' to 'slashcommands' in deploy-commands.js:7 to match the actual directory structure
- **Added safety check**: Added s.existsSync() guard to gracefully handle missing slashcommands directory

## Problem
deploy-commands.js referenced src/commands but the actual folder is src/slashcommands, which breaks the deployment script completely.

## Testing
- Verified the slashcommands directory exists with the expected command files (avatar.js, ping.js, server.js, uptime.js, user.js)