### PR TITLE
fix: correct slashcommands directory path (Fixes #1)

### DIFF
--- a/src/deploy-commands.js
+++ b/src/deploy-commands.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const path = require('path');
 
 const commands = [];
-const commandsPath = path.join(__dirname, 'commands');
+const commandsPath = path.join(__dirname, 'slashcommands');
 const commandFiles = fs.readdirSync(commandsPath).filter(f => f.endsWith('.js'));
 
 for (const file of commandFiles) {


### PR DESCRIPTION
This PR fixes the directory path in deploy-commands.js by changing 'commands' to 'slashcommands'. Claiming issue #1 from the community bounty #21.