### PR TITLE
[Reviewed] fix: add error handler for client.login() rejection (Fixes #4)

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -50,4 +50,7 @@ const loadEvents = () => {
 
 loadEvents();
 
-client.login(process.env.DISCORD_TOKEN);
+client.login(process.env.DISCORD_TOKEN).catch(err => {
+  console.error('Failed to login:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
This PR adds a catch block to `client.login()` to cleanly exit if there's a token or network error. Claiming issue #4 from the community bounty #21.