### PR TITLE
[Reviewed] fix: add folder existence checks (Item 3)

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -35,6 +35,10 @@ loadCommands('prefixcommands', client.prefixCommands);
 
 const loadEvents = () => {
   const eventsPath = path.join(__dirname, 'events');
+  if (!fs.existsSync(eventsPath)) {
+    console.warn(`[WARNING] Events directory missing at ${eventsPath}. Auto-creating it.`);
+    fs.mkdirSync(eventsPath, { recursive: true });
+  }
   const eventFiles = fs.readdirSync(eventsPath).filter(f => f.endsWith('.js'));
   
   for (const file of eventFiles) {

--- a/src/deploy-commands.js
+++ b/src/deploy-commands.js
@@ -5,6 +5,10 @@ const path = require('path');
 
 const commands = [];
 const commandsPath = path.join(__dirname, 'commands');
+if (!fs.existsSync(commandsPath)) {
+  console.warn(`[WARNING] Commands directory missing at ${commandsPath}. Auto-creating it.`);
+  fs.mkdirSync(commandsPath, { recursive: true });
+}
 const commandFiles = fs.readdirSync(commandsPath).filter(f => f.endsWith('.js'));
 
 for (const file of commandFiles) {


### PR DESCRIPTION
This PR adds `fs.existsSync` checks before attempting to read directories for commands and events. If they do not exist, it warns and auto-creates them instead of crashing. Claiming issue #3 from the community bounty #21.