### PR TITLE
[Reviewed] fix: add robust user-facing error feedback for slash commands

### DIFF
--- a/src/events/interactionCreate.js
+++ b/src/events/interactionCreate.js
@@ -9,8 +9,20 @@ module.exports = {
     try {
       await command.execute(interaction);
     } catch (error) {
-      console.error(error);
-      await interaction.reply({ content: 'There was an error while executing this command!', ephemeral: true });
+      console.error(`[Error executing ${interaction.commandName}]:`, error);
+      
+      // Check if the interaction was already acknowledged to prevent crashes
+      if (interaction.replied || interaction.deferred) {
+        await interaction.followUp({ 
+          content: 'There was an error while executing this command!', 
+          ephemeral: true 
+        });
+      } else {
+        await interaction.reply({ 
+          content: 'There was an error while executing this command!', 
+          ephemeral: true 
+        });
+      }
     }
   },
 };


### PR DESCRIPTION
Resolves Item #7 from Issue #21.

Updated the `interactionCreate` event handler. Previously, command execution errors would fail silently if the interaction had already been deferred or replied to, throwing an `InteractionAlreadyReplied` error and leaving the user with a frozen "Thinking..." state. 

This update safely checks `interaction.replied` and `interaction.deferred` and uses `followUp` or `reply` accordingly, ensuring the user always gets ephemeral feedback on a crash.