### PR TITLE
[Reviewed] fix: update commands path in deploy-commands.js (Item 1)

### DIFF
--- a/src/deploy-commands.js
+++ b/src/deploy-commands.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const path = require('path');
 
 const commands = [];
-const commandsPath = path.join(__dirname, 'commands');
+const commandsPath = path.join(__dirname, 'slashcommands');
 const commandFiles = fs.readdirSync(commandsPath).filter(f => f.endsWith('.js'));
 
 for (const file of commandFiles) {


### PR DESCRIPTION
Fixes Item 1 in Issue #21. The deployment script was referencing a non-existent 'commands' directory instead of 'slashcommands'.