### PR TITLE
[Reviewed] fix: add folder existence checks (Item 3)

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -35,6 +35,10 @@ loadCommands('prefixcommands', client.prefixCommands);
 
 const loadEvents = () => {
   const eventsPath = path.join(__dirname, 'events');
+  if (!fs.existsSync(eventsPath)) {
+    console.warn('Warning: events directory not found.');
+    return;
+  }
   const eventFiles = fs.readdirSync(eventsPath).filter(f => f.endsWith('.js'));
   
   for (const file of eventFiles) {

--- a/src/deploy-commands.js
+++ b/src/deploy-commands.js
@@ -4,7 +4,13 @@ const fs = require('fs');
 const path = require('path');
 
 const commands = [];
-const commandsPath = path.join(__dirname, 'commands');
+const commandsPath = path.join(__dirname, 'slashcommands');
+
+if (!fs.existsSync(commandsPath)) {
+  console.error(`Error: The directory ${commandsPath} does not exist.`);
+  process.exit(1);
+}
+
 const commandFiles = fs.readdirSync(commandsPath).filter(f => f.endsWith('.js'));
 
 for (const file of commandFiles) {


### PR DESCRIPTION
Fixes Item 3 in Issue #21. Added existence checks for 'slashcommands' and 'events' directories to prevent startup crashes. Relates to Issue #3.