### PR TITLE
[Reviewed] fix: add robust permission checks to interactionCreate

### DIFF
--- a/src/events/interactionCreate.js
+++ b/src/events/interactionCreate.js
@@ -3,14 +3,40 @@ module.exports = {
   async execute(interaction) {
     if (!interaction.isChatInputCommand()) return;
 
+    // Item #6 Fix: Check if the bot has permission to send messages in this channel
+    // We use appPermissions to check the bot's specific permissions for this interaction
+    if (interaction.guild && !interaction.appPermissions.has('SendMessages')) {
+      try {
+        return await interaction.reply({ 
+          content: 'I do not have permission to send messages in this channel! Please ask an admin to update my permissions.', 
+          ephemeral: true 
+        });
+      } catch (e) {
+        // If the bot lacks permission to even reply, just log it and abort
+        console.error(`[Permission Error]: Could not reply to ${interaction.commandName} in ${interaction.channelId}`);
+        return;
+      }
+    }
+
     const command = interaction.client.commands.get(interaction.commandName);
     if (!command) return;
 
     try {
       await command.execute(interaction);
     } catch (error) {
-      console.error(error);
-      await interaction.reply({ content: 'There was an error while executing this command!', ephemeral: true });
+      console.error(`[Error executing ${interaction.commandName}]:`, error);
+      
+      if (interaction.replied || interaction.deferred) {
+        await interaction.followUp({ 
+          content: 'There was an error while executing this command!', 
+          ephemeral: true 
+        });
+      } else {
+        await interaction.reply({ 
+          content: 'There was an error while executing this command!', 
+          ephemeral: true 
+        });
+      }
     }
   },
 };


### PR DESCRIPTION
Resolves Item #6 from Issue #21.

Added an early return check in `interactionCreate.js` using `interaction.appPermissions.has('SendMessages')`. 

If the bot is missing permissions, it attempts to send an ephemeral warning to the user. If the permissions are so restrictive that even the reply fails, it catches the error and logs it to the console to prevent the bot from crashing. Built on top of the error handling established in PR #28.