### PR TITLE
feat: add guild deploy script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "node src/bot.js",
     "dev": "node --watch src/bot.js",
-    "deploy": "node src/deploy-commands.js"
+    "deploy": "node src/deploy-commands.js",
+    "deploy:guild": "node scripts/deploy-guild.js"
   },
   "dependencies": {
     "discord.js": "^14.14.1",

--- a/scripts/deploy-guild.js
+++ b/scripts/deploy-guild.js
@@ -1,0 +1,38 @@
+require('dotenv').config();
+
+const { REST, Routes } = require('discord.js');
+const fs = require('fs');
+const path = require('path');
+
+const requiredEnv = ['DISCORD_TOKEN', 'CLIENT_ID', 'GUILD_ID'];
+const missingEnv = requiredEnv.filter((key) => !process.env[key]);
+
+if (missingEnv.length > 0) {
+  console.error(`Missing required environment variables: ${missingEnv.join(', ')}`);
+  process.exit(1);
+}
+
+const commands = [];
+const commandsPath = path.join(__dirname, '..', 'src', 'slashcommands');
+const commandFiles = fs.readdirSync(commandsPath).filter((file) => file.endsWith('.js'));
+
+for (const file of commandFiles) {
+  const command = require(path.join(commandsPath, file));
+  commands.push(command.data.toJSON());
+}
+
+const rest = new REST({ version: '10' }).setToken(process.env.DISCORD_TOKEN);
+
+(async () => {
+  try {
+    console.log(`Started refreshing ${commands.length} guild (/) commands for ${process.env.GUILD_ID}.`);
+    await rest.put(
+      Routes.applicationGuildCommands(process.env.CLIENT_ID, process.env.GUILD_ID),
+      { body: commands },
+    );
+    console.log('Successfully reloaded guild (/) commands.');
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary\n- add a guild-only slash command deployment script for development testing\n- add an npm script alias: `npm run deploy:guild`\n- validate required env vars before calling Discord's REST API\n\n## Bounty\nResolves Item #9 from #21.\n\n## Verification\n- `node --check scripts/deploy-guild.js`\n- `npm run deploy:guild` exits cleanly with: `Missing required environment variables: DISCORD_TOKEN, CLIENT_ID, GUILD_ID` when local credentials are not configured\n