### PR TITLE
[Reviewed] feat: support guild scoped command deploys

### DIFF
--- a/src/deploy-commands.js
+++ b/src/deploy-commands.js
@@ -16,9 +16,14 @@ const rest = new REST({ version: '10' }).setToken(process.env.DISCORD_TOKEN);
 
 (async () => {
   try {
-    console.log('Started refreshing application (/) commands.');
-    await rest.put(Routes.applicationCommands(process.env.CLIENT_ID), { body: commands });
-    console.log('Successfully reloaded application (/) commands.');
+    const route = process.env.GUILD_ID
+      ? Routes.applicationGuildCommands(process.env.CLIENT_ID, process.env.GUILD_ID)
+      : Routes.applicationCommands(process.env.CLIENT_ID);
+    const scope = process.env.GUILD_ID ? `guild ${process.env.GUILD_ID}` : 'global';
+
+    console.log(`Started refreshing ${scope} application (/) commands.`);
+    await rest.put(route, { body: commands });
+    console.log(`Successfully reloaded ${scope} application (/) commands.`);
   } catch (error) {
     console.error(error);
   }


### PR DESCRIPTION
## Summary\n- support `GUILD_ID` in `src/deploy-commands.js`\n- deploy to `Routes.applicationGuildCommands` when `GUILD_ID` is set\n- keep existing global deploy behavior when `GUILD_ID` is not set\n\n## Bounty\nResolves Item #8 from #21.\n\n## Verification\n- `node --check src/deploy-commands.js`\n\nI did not run a live Discord deploy because local Discord credentials are not configured.\n