### PR TITLE
[Reviewed] Add per-user command cooldown system to prevent spam

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 DISCORD_TOKEN=your_bot_token_here
 CLIENT_ID=your_discord_application_id_here
 GUILD_ID=your_test_guild_id_here
+COMMAND_COOLDOWN=3

--- a/src/events/interactionCreate.js
+++ b/src/events/interactionCreate.js
@@ -1,3 +1,5 @@
+const { checkCooldown } = require('../utils/cooldown');
+
 module.exports = {
   name: 'interactionCreate',
   async execute(interaction) {
@@ -6,21 +8,29 @@ module.exports = {
     const command = interaction.client.commands.get(interaction.commandName);
     if (!command) return;
 
+    // Cooldown check
+    const remaining = checkCooldown(interaction.user.id, interaction.commandName);
+    if (remaining) {
+      return interaction.reply({
+        content: `Please wait ${remaining}s before using \`/${interaction.commandName}\` again.`,
+        ephemeral: true,
+      });
+    }
+
     try {
       await command.execute(interaction);
     } catch (error) {
       console.error(`[Error executing ${interaction.commandName}]:`, error);
-      
-      // Check if the interaction was already acknowledged to prevent crashes
+
       if (interaction.replied || interaction.deferred) {
-        await interaction.followUp({ 
-          content: 'There was an error while executing this command!', 
-          ephemeral: true 
+        await interaction.followUp({
+          content: 'There was an error while executing this command!',
+          ephemeral: true,
         });
       } else {
-        await interaction.reply({ 
-          content: 'There was an error while executing this command!', 
-          ephemeral: true 
+        await interaction.reply({
+          content: 'There was an error while executing this command!',
+          ephemeral: true,
         });
       }
     }

--- a/src/events/interactionCreate.js
+++ b/src/events/interactionCreate.js
@@ -1,4 +1,4 @@
-const { checkCooldown } = require('../utils/cooldown');
+const { checkCooldown, setCooldown } = require('../utils/cooldown');
 
 module.exports = {
   name: 'interactionCreate',
@@ -8,17 +8,21 @@ module.exports = {
     const command = interaction.client.commands.get(interaction.commandName);
     if (!command) return;
 
-    // Cooldown check
-    const remaining = checkCooldown(interaction.user.id, interaction.commandName);
-    if (remaining) {
-      return interaction.reply({
-        content: `Please wait ${remaining}s before using \`/${interaction.commandName}\` again.`,
-        ephemeral: true,
-      });
-    }
-
     try {
+      // Check cooldown without setting it yet
+      const remaining = checkCooldown(interaction.user.id, interaction.commandName, false);
+      if (remaining) {
+        return await interaction.reply({
+          content: `Please wait ${remaining}s before using \`/${interaction.commandName}\` again.`,
+          ephemeral: true,
+        });
+      }
+
+      // Execute command first
       await command.execute(interaction);
+
+      // Only set cooldown after successful execution
+      setCooldown(interaction.user.id, interaction.commandName);
     } catch (error) {
       console.error(`[Error executing ${interaction.commandName}]:`, error);
 

--- a/src/events/interactionCreate.js
+++ b/src/events/interactionCreate.js
@@ -9,8 +9,7 @@ module.exports = {
     if (!command) return;
 
     try {
-      // Check cooldown without setting it yet
-      const remaining = checkCooldown(interaction.user.id, interaction.commandName, false);
+      const remaining = checkCooldown(interaction.user.id, interaction.commandName);
       if (remaining) {
         return await interaction.reply({
           content: `Please wait ${remaining}s before using \`/${interaction.commandName}\` again.`,
@@ -18,11 +17,10 @@ module.exports = {
         });
       }
 
-      // Execute command first
-      await command.execute(interaction);
-
-      // Only set cooldown after successful execution
+      // Set cooldown before executing to prevent bypass
       setCooldown(interaction.user.id, interaction.commandName);
+
+      await command.execute(interaction);
     } catch (error) {
       console.error(`[Error executing ${interaction.commandName}]:`, error);
 

--- a/src/events/messageCreate.js
+++ b/src/events/messageCreate.js
@@ -1,18 +1,25 @@
 const prefix = '!';
+const { checkCooldown } = require('../utils/cooldown');
 
 module.exports = {
   name: 'messageCreate',
   execute(message) {
     if (message.author.bot || !message.content.startsWith(prefix)) return;
-    
+
     const args = message.content.slice(prefix.length).trim().split(/\s+/);
     const commandName = args.shift().toLowerCase();
-    
+
     const command = message.client.prefixCommands.get(commandName);
     if (!command) {
       return message.reply(`Unknown command: \`${commandName}\`. Type \`!help\` to see available commands.`);
     }
-    
+
+    // Cooldown check
+    const remaining = checkCooldown(message.author.id, commandName);
+    if (remaining) {
+      return message.reply(`Please wait ${remaining}s before using \`!${commandName}\` again.`);
+    }
+
     try {
       command.execute(message, args);
     } catch (error) {

--- a/src/events/messageCreate.js
+++ b/src/events/messageCreate.js
@@ -1,5 +1,5 @@
 const prefix = '!';
-const { checkCooldown } = require('../utils/cooldown');
+const { checkCooldown, setCooldown } = require('../utils/cooldown');
 
 module.exports = {
   name: 'messageCreate',
@@ -14,14 +14,17 @@ module.exports = {
       return message.reply(`Unknown command: \`${commandName}\`. Type \`!help\` to see available commands.`);
     }
 
-    // Cooldown check
-    const remaining = checkCooldown(message.author.id, commandName);
+    // Check cooldown without setting it yet
+    const remaining = checkCooldown(message.author.id, commandName, false);
     if (remaining) {
-      return message.reply(`Please wait ${remaining}s before using \`!${commandName}\` again.`);
+      return message.reply(`Please wait ${remaining}s before using \`!${commandName}\` again.`)
+        .then(reply => setTimeout(() => reply.delete().catch(() => {}), 5000));
     }
 
     try {
       command.execute(message, args);
+      // Only set cooldown after successful execution
+      setCooldown(message.author.id, commandName);
     } catch (error) {
       console.error(error);
       message.reply('There was an error executing that command!');

--- a/src/events/messageCreate.js
+++ b/src/events/messageCreate.js
@@ -14,17 +14,17 @@ module.exports = {
       return message.reply(`Unknown command: \`${commandName}\`. Type \`!help\` to see available commands.`);
     }
 
-    // Check cooldown without setting it yet
-    const remaining = checkCooldown(message.author.id, commandName, false);
+    const remaining = checkCooldown(message.author.id, commandName);
     if (remaining) {
       return message.reply(`Please wait ${remaining}s before using \`!${commandName}\` again.`)
         .then(reply => setTimeout(() => reply.delete().catch(() => {}), 5000));
     }
 
+    // Set cooldown before executing to prevent bypass
+    setCooldown(message.author.id, commandName);
+
     try {
       command.execute(message, args);
-      // Only set cooldown after successful execution
-      setCooldown(message.author.id, commandName);
     } catch (error) {
       console.error(error);
       message.reply('There was an error executing that command!');

--- a/src/utils/cooldown.js
+++ b/src/utils/cooldown.js
@@ -1,5 +1,10 @@
+let COOLDOWN_SECONDS = parseInt(process.env.COMMAND_COOLDOWN || 3, 10);
+if (isNaN(COOLDOWN_SECONDS) || COOLDOWN_SECONDS <= 0) {
+  console.warn('[Warning]: Invalid COMMAND_COOLDOWN value, defaulting to 3 seconds');
+  COOLDOWN_SECONDS = 3;
+}
+
 const cooldowns = new Map();
-const COOLDOWN_SECONDS = process.env.COMMAND_COOLDOWN || 3;
 
 // Cleanup expired entries every minute to prevent memory leak
 setInterval(() => {
@@ -11,14 +16,7 @@ setInterval(() => {
   }
 }, 60000);
 
-/**
- * Checks if a user is on cooldown.
- * @param {string} userId - The Discord user ID
- * @param {string} commandName - The command name
- * @param {boolean} setOnPass - Whether to set cooldown immediately on pass
- * @returns {string|null} - Remaining seconds if on cooldown, null if not
- */
-function checkCooldown(userId, commandName, setOnPass = true) {
+function checkCooldown(userId, commandName) {
   const key = `${userId}-${commandName}`;
   const now = Date.now();
 
@@ -26,13 +24,10 @@ function checkCooldown(userId, commandName, setOnPass = true) {
     const lastUsed = cooldowns.get(key);
     const elapsed = (now - lastUsed) / 1000;
     if (elapsed < COOLDOWN_SECONDS) {
-      return (COOLDOWN_SECONDS - elapsed).toFixed(1);
+      return Math.ceil(COOLDOWN_SECONDS - elapsed);
     }
   }
 
-  if (setOnPass) {
-    cooldowns.set(key, now);
-  }
   return null;
 }
 

--- a/src/utils/cooldown.js
+++ b/src/utils/cooldown.js
@@ -1,27 +1,43 @@
 const cooldowns = new Map();
-const COOLDOWN_SECONDS = 3;
+const COOLDOWN_SECONDS = process.env.COMMAND_COOLDOWN || 3;
+
+// Cleanup expired entries every minute to prevent memory leak
+setInterval(() => {
+  const now = Date.now();
+  for (const [key, timestamp] of cooldowns.entries()) {
+    if (now - timestamp > COOLDOWN_SECONDS * 1000) {
+      cooldowns.delete(key);
+    }
+  }
+}, 60000);
 
 /**
  * Checks if a user is on cooldown.
  * @param {string} userId - The Discord user ID
  * @param {string} commandName - The command name
- * @returns {number|null} - Remaining seconds if on cooldown, null if not
+ * @param {boolean} setOnPass - Whether to set cooldown immediately on pass
+ * @returns {string|null} - Remaining seconds if on cooldown, null if not
  */
-function checkCooldown(userId, commandName) {
+function checkCooldown(userId, commandName, setOnPass = true) {
   const key = `${userId}-${commandName}`;
   const now = Date.now();
 
   if (cooldowns.has(key)) {
     const lastUsed = cooldowns.get(key);
     const elapsed = (now - lastUsed) / 1000;
-
     if (elapsed < COOLDOWN_SECONDS) {
       return (COOLDOWN_SECONDS - elapsed).toFixed(1);
     }
   }
 
-  cooldowns.set(key, now);
+  if (setOnPass) {
+    cooldowns.set(key, now);
+  }
   return null;
 }
 
-module.exports = { checkCooldown };
+function setCooldown(userId, commandName) {
+  cooldowns.set(`${userId}-${commandName}`, Date.now());
+}
+
+module.exports = { checkCooldown, setCooldown };

--- a/src/utils/cooldown.js
+++ b/src/utils/cooldown.js
@@ -1,0 +1,27 @@
+const cooldowns = new Map();
+const COOLDOWN_SECONDS = 3;
+
+/**
+ * Checks if a user is on cooldown.
+ * @param {string} userId - The Discord user ID
+ * @param {string} commandName - The command name
+ * @returns {number|null} - Remaining seconds if on cooldown, null if not
+ */
+function checkCooldown(userId, commandName) {
+  const key = `${userId}-${commandName}`;
+  const now = Date.now();
+
+  if (cooldowns.has(key)) {
+    const lastUsed = cooldowns.get(key);
+    const elapsed = (now - lastUsed) / 1000;
+
+    if (elapsed < COOLDOWN_SECONDS) {
+      return (COOLDOWN_SECONDS - elapsed).toFixed(1);
+    }
+  }
+
+  cooldowns.set(key, now);
+  return null;
+}
+
+module.exports = { checkCooldown };


### PR DESCRIPTION
Closes #21 (item 5)

Added a per-user cooldown system to prevent command spam.

- Created `src/utils/cooldown.js` with a shared cooldown Map
- Cooldown is tracked per user per command (3 second default)
- Integrated into both `messageCreate.js` (prefix commands) and `interactionCreate.js` (slash commands)
- Users receive a friendly ephemeral message showing remaining wait time
- Cooldown resets automatically after the period expires