### PR TITLE
wrap event handlers in try/catch to prevent process crashes

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -54,9 +54,21 @@ const loadEvents = () => {
     try {
       const event = require(filePath);
       if (event.once) {
-        client.once(event.name, (...args) => event.execute(...args));
+        client.once(event.name, async (...args) => {
+          try {
+            await event.execute(...args);
+          } catch (error) {
+            console.error(`[Error]: Event handler '${event.name}' threw an error:`, error);
+          }
+        });
       } else {
-        client.on(event.name, (...args) => event.execute(...args));
+        client.on(event.name, async (...args) => {
+          try {
+            await event.execute(...args);
+          } catch (error) {
+            console.error(`[Error]: Event handler '${event.name}' threw an error:`, error);
+          }
+        });
       }
     } catch (error) {
       console.error(`[Error]: Failed to load event at ${file}:`, error.message);


### PR DESCRIPTION
Closes #21 (item 4)

Wrapped `event.execute(...args)` in try/catch for both `client.once` 
and `client.on` event handlers.

- Prevents uncaught errors from crashing the entire bot process
- Logs error with event name for easier debugging
- Graceful degradation — other events continue working if one fails